### PR TITLE
change name of project build-flask-app to buildflaskapp

### DIFF
--- a/json/projects.js
+++ b/json/projects.js
@@ -121,8 +121,8 @@ export default {
         },
         {
             github_username: 'kouul',
-            repo_name: 'build-flask-app',
-            repo_link: 'https://pypi.org/project/build-flask-app/',
+            repo_name: 'buildflaskapp',
+            repo_link: 'https://github.com/askyourkode/buildflaskapp/',
             description: 'A flask app boilerplate template generator.',
             language_tag: 'Python'
         }


### PR DESCRIPTION
I changed the name to make it compatible on Windows. Previous name was causing some weird error when running on a windows os